### PR TITLE
Fix condition where low has value of `0`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ function * enumerate(array) {
     }
 }
 
-const hasProperties = obj => obj.properties && obj.identity && obj.identity.low;
+const hasProperties = obj => obj.properties && obj.identity && (typeof obj.identity.low === 'number');
 
 const parseRecord = record => {
     // If null or value


### PR DESCRIPTION
Results get formatted incorrectly when their low value is 0 as the expression evaluates to false.

```
{
  low: 0,
  high: 20
}
```
  